### PR TITLE
fix GeographicLib 2.0

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -19,6 +19,8 @@ pkgbase = ros-noetic-libmavconn
 	depends = boost
 	depends = console-bridge
 	source = ros-noetic-libmavconn-1.13.0.tar.gz::https://github.com/mavlink/mavros/archive/1.13.0.tar.gz
+	source = https://github.com/mavlink/mavros/pull/1760.patch
 	sha256sums = c7cd33fe3582c427744d251383b0befb0766ab29cd6191a3f29f6a439aa26813
+	sha256sums = SKIP
 
 pkgname = ros-noetic-libmavconn

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-noetic-libmavconn
 	pkgdesc = ROS - MAVLink communication library.
 	pkgver = 1.13.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://wiki.ros.org/libmavconn
 	arch = i686
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='https://wiki.ros.org/libmavconn'
 pkgname='ros-noetic-libmavconn'
 pkgver=1.13.0
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=1
+pkgrel=2
 license=('GPLv3, LGPLv3, BSD')
 
 ros_makedepends=(ros-noetic-mavlink
@@ -24,6 +24,10 @@ depends=(${ros_depends[@]}
 _dir="mavros-${pkgver}/libmavconn"
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/mavlink/mavros/archive/${pkgver}.tar.gz")
 sha256sums=('c7cd33fe3582c427744d251383b0befb0766ab29cd6191a3f29f6a439aa26813')
+
+prepare() {
+  sed -i '11s/Geographic)/GeographicLib)/' ${_dir}/cmake/Modules/FindGeographicLib.cmake
+}
 
 build() {
   # Use ROS environment variables

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,11 +22,12 @@ depends=(${ros_depends[@]}
   console-bridge)
 
 _dir="mavros-${pkgver}/libmavconn"
-source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/mavlink/mavros/archive/${pkgver}.tar.gz")
-sha256sums=('c7cd33fe3582c427744d251383b0befb0766ab29cd6191a3f29f6a439aa26813')
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/mavlink/mavros/archive/${pkgver}.tar.gz"
+        "https://github.com/mavlink/mavros/pull/1760.patch")
+sha256sums=('c7cd33fe3582c427744d251383b0befb0766ab29cd6191a3f29f6a439aa26813' SKIP)
 
 prepare() {
-  sed -i '11s/Geographic)/GeographicLib)/' ${_dir}/cmake/Modules/FindGeographicLib.cmake
+  patch --directory="${srcdir}/mavros-${pkgver}" --forward --strip=1 --input="${srcdir}/1760.patch"
 }
 
 build() {


### PR DESCRIPTION
This PR should make the ros-noetic-mavros can be build with GeographicLib 2.0. I want to use patch from upstream PR but there is no noetic branch.